### PR TITLE
Changed gradle deprecated methods by the new

### DIFF
--- a/jacoco.gradle
+++ b/jacoco.gradle
@@ -18,11 +18,11 @@ if (shouldApplyJacoco(project, ignoredByJacoco)) {
         reports {
             html {
                 enabled true
-                destination 'build/reports/jacoco/full'
+                destination file('build/reports/jacoco/full')
             }
             xml {
                 enabled true
-                destination 'build/reports/jacoco/full/jacocoFullReport.xml'
+                destination file('build/reports/jacoco/full/jacocoFullReport.xml')
             }
         }
 

--- a/quality.gradle
+++ b/quality.gradle
@@ -54,10 +54,10 @@ task findbugs(type: FindBugs, dependsOn: "assemble", group: 'verification') {
         xml.enabled = false
         html.enabled = !xml.enabled
         xml {
-            destination "$projectDir.absolutePath/build/reports/findbugs/findbugs.xml"
+            destination file("$projectDir.absolutePath/build/reports/findbugs/findbugs.xml")
         }
         html {
-            destination "$projectDir.absolutePath/build/reports/findbugs/findbugs.html"
+            destination file("$projectDir.absolutePath/build/reports/findbugs/findbugs.html")
         }
     }
 
@@ -81,10 +81,10 @@ task pmd(type: Pmd, group: 'verification') {
         xml.enabled = true
         html.enabled = true
         xml {
-            destination "$projectDir.absolutePath/build/reports/pmd/pmd.xml"
+            destination file("$projectDir.absolutePath/build/reports/pmd/pmd.xml")
         }
         html {
-            destination "$projectDir.absolutePath/build/reports/pmd/pmd.html"
+            destination file("$projectDir.absolutePath/build/reports/pmd/pmd.html")
         }
     }
 }


### PR DESCRIPTION
#17 Use the method `ConfigurableReport.setDestination(File)` instead `ConfigurableReport.setDestination(Object)`